### PR TITLE
rewrite changed_files_from_git

### DIFF
--- a/lib/TestTracker.pm
+++ b/lib/TestTracker.pm
@@ -39,11 +39,11 @@ sub git_base_dir {
 }
 
 sub changed_files_from_git {
-    my @git_args = @_;
+    my $diff_arg = shift;
 
     my @cmd = qw(git diff --name-only);
-    if (@git_args) {
-        push @cmd, @git_args;
+    if ($diff_arg) {
+        push @cmd, $diff_arg;
     }
 
     my @files = capture(@cmd);
@@ -258,11 +258,11 @@ sub git2rel {
 }
 
 sub tests_for_git_changes {
-    my @git_log_args = @_;
+    my $diff_arg = shift;
 
     my %config = TestTracker::Config::load();
 
-    my @changed_files = changed_files_from_git(@git_log_args);
+    my @changed_files = changed_files_from_git($diff_arg);
 
     my @tests;
     if (@changed_files) {

--- a/lib/TestTracker.pm
+++ b/lib/TestTracker.pm
@@ -342,11 +342,6 @@ sub format_duration {
     return sprintf("%02d:%02d:%02d", $hours, $minutes, $seconds);
 }
 
-sub git_status_z {
-    my @lines = capture('git', 'status', '-zs');
-    return @lines;
-}
-
 sub get_test_id {
     my ($dbh, $db_prefix, $test_name) = @_;
     unless ($test_name) {

--- a/t/unit/TestTracker/changed_files_from_git.t
+++ b/t/unit/TestTracker/changed_files_from_git.t
@@ -34,7 +34,7 @@ my $test_dir = File::Temp->newdir(TMPDIR => 1);
 my $git_dir = create_a_repo($test_dir);
 chdir $git_dir;
 
-my $git_arg = TestTracker::default_git_arg();
+my $git_arg = '';
 
 my $db_filename = db_filename();
 my $conf_filename = conf_filename();


### PR DESCRIPTION
Rewrite `changed_files_from_git()`:

- avoid having to parse `git status` output
- do not append untracked files when non-empty `$diff_arg` has been passed in
- reimplement default heuristic for empty `$diff_arg`
- only include changes in HEAD instead of also including changes made to
 upstream branch (more or less, triple dot versus double dot syntax)

Fixes #35
Closes #25