### PR TITLE
update documentation

### DIFF
--- a/bin/test-tracker-prove
+++ b/bin/test-tracker-prove
@@ -245,7 +245,7 @@ __END__
 
 =head1 SYNOPSIS
 
-    test-tracker-prove [options] [test_path ...]
+    test-tracker-prove [options] [prove options] [test_path ...]
 
      Options:
        --lsf                                bsub test(s) to your LSF cluster
@@ -253,5 +253,7 @@ __END__
        --junit                              enable JUnit output
        --help                               brief help message
        --man                                full documentation
+
+    The above options are intercepted by `test-tracker-prove` but all other options/arguments are passed on to `prove`.
 
 =cut


### PR DESCRIPTION
Update documentation to make it clearer that extra arguments are passed
on to `prove`.

Fixes #29.