### PR TITLE
check that an upstream is set if no value is given for --git

### DIFF
--- a/lib/TestTracker.pm
+++ b/lib/TestTracker.pm
@@ -305,6 +305,7 @@ sub parse_args {
     # --git is an optional string argument so if it is passed as last option and the users also passes an argument (test or module path) then Getopt::Long may mistakenly identify that as the value to this option. So we check if it is a file and throw it back on @ARGV if so.
     if ($options{git} && -f $options{git}) {
         unshift @ARGV, $options{git};
+        $options{git} = '';
     }
 
     if (defined($options{git}) && $options{git} eq '') {

--- a/lib/TestTracker.pm
+++ b/lib/TestTracker.pm
@@ -309,6 +309,10 @@ sub parse_args {
     }
 
     if (defined($options{git}) && $options{git} eq '') {
+        if (system('git rev-parse @{u} 1> /dev/null 2> /dev/null') != 0) {
+            print STDERR "test-tracker: --git option requires argument if an upstream branch is not set\n";
+            exit(1);
+        }
         $options{git} = default_git_arg();
     }
 


### PR DESCRIPTION
Check that an upstream is set if no value is given for --git because
otherwise a somewhat unhelpful error occurs:

``` fatal: No upstream configured for branch 'foobar'
"git" unexpectedly returned exit value 128 ...
```

Fixes #36.